### PR TITLE
#5 Added a function to safely output byte sequences to the logger's trait.

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -31,9 +31,9 @@ pub trait Logger {
     /// バイト列を安全に 0xXX 表記でログ出力
     fn log_bytes(&mut self, label: &str, bytes: &[u8]) {
         let mut out = String::<128>::new();
-        if write!(&mut out, "{}: ", label).is_ok() {
+        if write!(&mut out, "{label}: ").is_ok() {
             for b in bytes {
-                if write!(&mut out, "0x{:02X} ", b).is_err() {
+                if write!(&mut out, "0x{b:02X} ").is_err() {
                     // Buffer is full, append "..." to indicate truncation and stop.
                     let _ = out.push_str("...");
                     break;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -31,9 +31,9 @@ pub trait Logger {
     /// バイト列を安全に 0xXX 表記でログ出力
     fn log_bytes(&mut self, label: &str, bytes: &[u8]) {
         let mut out = String::<128>::new();
-        let _ = write!(&mut out, "{}: ", label);
+        let _ = write!(&mut out, "{label}: ");
         for b in bytes {
-            let _ = write!(&mut out, "0x{:02X} ", b);
+            let _ = write!(&mut out, "0x{b:02X} ");
         }
         self.log(out.as_str());
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -31,9 +31,17 @@ pub trait Logger {
     /// バイト列を安全に 0xXX 表記でログ出力
     fn log_bytes(&mut self, label: &str, bytes: &[u8]) {
         let mut out = String::<128>::new();
-        let _ = write!(&mut out, "{label}: ");
-        for b in bytes {
-            let _ = write!(&mut out, "0x{b:02X} ");
+        if write!(&mut out, "{}: ", label).is_ok() {
+            for b in bytes {
+                if write!(&mut out, "0x{:02X} ", b).is_err() {
+                    // Buffer is full, append "..." to indicate truncation and stop.
+                    let _ = out.push_str("...");
+                    break;
+                }
+            }
+        } else {
+            // Label and/or separator was too long. Add ellipsis to what was written.
+            let _ = out.push_str("...");
         }
         self.log(out.as_str());
     }


### PR DESCRIPTION
# 🚀 Pull Request
---
- Refer Issue: #5 

## Response details
- Bytes are safety output by this function.
```rust
fn log_bytes(&mut self, label: &str, bytes: &[u8]) {
        let mut out = String::<128>::new();
        let _ = write!(&mut out, "{}: ", label);
        for b in bytes {
            let _ = write!(&mut out, "0x{:02X} ", b);
        }
        self.log(out.as_str());
    }
```

## Change contents

- [x] 新規機能追加
- [ ] リファクタリング
- [ ] バグ修正
- [ ] CI / ビルド設定の修正
- [ ] ドキュメントの更新
---
close #5 