### PR TITLE
adapt_serial macro supports e-hal 1.0 & e-io latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,50 +3,90 @@
 version = 4
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "dvcdbg"
 version = "0.1.2"
 dependencies = [
  "embedded-hal",
- "embedded-io",
  "heapless",
- "nb",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
 
 [[package]]
 name = "hash32"
-version = "0.3.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
+ "atomic-polyfill",
  "hash32",
+ "rustc_version",
+ "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -56,7 +96,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.2"
 dependencies = [
  "embedded-hal",
  "heapless",
+ "nb",
 ]
 
 [[package]]
@@ -40,6 +41,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "embedded-hal",
  "embedded-io",
  "heapless",
+ "nb",
 ]
 
 [[package]]
@@ -47,6 +48,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,90 +3,50 @@
 version = 4
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "dvcdbg"
 version = "0.1.2"
 dependencies = [
  "embedded-hal",
+ "embedded-io",
  "heapless",
- "nb 1.1.0",
+ "nb",
 ]
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
- "spin",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.1.0",
 ]
 
 [[package]]
@@ -96,43 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,8 +13,8 @@ name = "dvcdbg"
 version = "0.1.2"
 dependencies = [
  "embedded-hal",
+ "embedded-io",
  "heapless",
- "nb",
 ]
 
 [[package]]
@@ -22,6 +22,12 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "hash32"
@@ -41,12 +47,6 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "nb"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "1.0.0"
-embedded-io = "0.6.1"
-heapless = "0.8"
-nb = "1.1.0"
+embedded-hal = "0.2.7"
+nb = "1.1"
+heapless = "0.7"
 
 [features]
 default = ["logger", "scanner", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 nb = "1.1"
-heapless = "0.7"
+heapless = "0.8.0"
+embedded-io = "0.6.1"
 
 [features]
 default = ["logger", "scanner", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 [dependencies]
 embedded-hal = "1.0.0"
 heapless = "0.8"
+nb = "1.1.0"
 
 [features]
 default = ["logger", "scanner", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ exclude = [
 
 [dependencies]
 embedded-hal = "1.0.0"
+embedded-io = "0.6.1"
 heapless = "0.8"
-nb = "1.1.0"
 
 [features]
 default = ["logger", "scanner", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 embedded-hal = "1.0.0"
 embedded-io = "0.6.1"
 heapless = "0.8"
+nb = "1.1.0"
 
 [features]
 default = ["logger", "scanner", "macros"]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -85,13 +85,24 @@ pub trait Logger {
     }
 }
 
-/// Adapter trait for low-level byte writes.
-/// 
-/// Typically implemented by wrappers around `embedded_hal::serial::Write<u8>`.
+use embedded_io::Write;
+
+/// Our adapter trait for byte-oriented serial.
+/// This replaces the old embedded-hal blocking::serial::Write<u8>.
 pub trait WriteAdapter {
-    /// Writes a single byte (blocking).
     fn write(&mut self, byte: u8);
 }
+
+impl<T> WriteAdapter for T
+where
+    T: Write,
+{
+    fn write(&mut self, byte: u8) {
+        // `Write::write` takes a buffer, so we wrap the single byte
+        let _ = self.write(&[byte]);
+    }
+}
+
 
 
 /// Logger that writes directly to any `core::fmt::Write` target.

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -90,16 +90,18 @@ use embedded_io::Write;
 /// Our adapter trait for byte-oriented serial.
 /// This replaces the old embedded-hal blocking::serial::Write<u8>.
 pub trait WriteAdapter {
-    fn write(&mut self, byte: u8);
+    type Error;
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error>;
 }
 
 impl<T> WriteAdapter for T
 where
     T: Write,
 {
-    fn write(&mut self, byte: u8) {
-        // `Write::write` takes a buffer, so we wrap the single byte
-        let _ = self.write(&[byte]);
+    type Error = T::Error;
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
+        // `Write::write_all` ensures the whole buffer is written.
+        self.write_all(&[byte])
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -85,6 +85,15 @@ pub trait Logger {
     }
 }
 
+/// Adapter trait for low-level byte writes.
+/// 
+/// Typically implemented by wrappers around `embedded_hal::serial::Write<u8>`.
+pub trait WriteAdapter {
+    /// Writes a single byte (blocking).
+    fn write(&mut self, byte: u8);
+}
+
+
 /// Logger that writes directly to any `core::fmt::Write` target.
 pub struct SerialLogger<'a, W: core::fmt::Write>(&'a mut W);
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -85,28 +85,6 @@ pub trait Logger {
     }
 }
 
-use embedded_io::Write;
-
-/// Our adapter trait for byte-oriented serial.
-/// This replaces the old embedded-hal blocking::serial::Write<u8>.
-pub trait WriteAdapter {
-    type Error;
-    fn write(&mut self, byte: u8) -> Result<(), Self::Error>;
-}
-
-impl<T> WriteAdapter for T
-where
-    T: Write,
-{
-    type Error = T::Error;
-    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
-        // `Write::write_all` ensures the whole buffer is written.
-        self.write_all(&[byte])
-    }
-}
-
-
-
 /// Logger that writes directly to any `core::fmt::Write` target.
 pub struct SerialLogger<'a, W: core::fmt::Write>(&'a mut W);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -102,7 +102,7 @@ macro_rules! adapt_serial {
 
     // AVR-HAL USART (ATmega)
     (avr_usart: $wrapper:ident, $write_fn:ident) => {
-        adapt_serial!(@avr_usart_impl $name: $wrapper, $write_fn);
+        adapt_serial!(@avr_usart_impl $wrapper, $write_fn);
     };
 
     // Generic serial type

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -86,7 +86,6 @@ macro_rules! adapt_serial {
         }
     };
 
-    // AVR-HAL USART (ATmega) with board type argument
     // Internal helper for AVR-HAL USARTs
     (@avr_usart_impl $name:ident : $wrapper:ident, $write_fn:ident) => {
         pub struct $wrapper<RX, TX, CLOCK>(
@@ -100,8 +99,7 @@ macro_rules! adapt_serial {
         );
     };
 
-    // AVR-HAL USART (ATmega)
-    (avr_usart: $name:ident : $wrapper:ident, $write_fn:ident) => {
+    (avr_usart: $name:ident, $wrapper:ident, $write_fn:ident) => {
         adapt_serial!(@avr_usart_impl $name: $wrapper, $write_fn);
     };
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! adapt_serial {
 
         impl<T> core::fmt::Write for $name<T>
         where
-            T: embedded_hal::blocking::serial::Write<u8>,
+            T: embedded_io::Write,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 for b in s.as_bytes() {
@@ -37,7 +37,7 @@ macro_rules! adapt_serial {
 
         impl<T> dvcdbg::logger::WriteAdapter for $name<T>
         where
-            T: embedded_hal::blocking::serial::Write<u8>,
+            T: embedded_io::Write,
         {
             fn write(&mut self, byte: u8) {
                 let _ = nb::block!(self.0.write(byte));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,16 +45,15 @@ macro_rules! adapt_serial {
         }
 
         impl<T> core::fmt::Write for $name<T>
-        where
-            T: embedded_io::Write<Error = $err_ty>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
-                self.0.write_all(s.as_bytes())
+                use embedded_io::Write;
+                self.write_all(s.as_bytes())
                     .map_err(|_| core::fmt::Error)
             }
-
             fn flush(&mut self) -> core::fmt::Result {
-                self.0.flush().map_err(|_| core::fmt::Error)
+                use embedded_io::Write;
+                self.flush().map_err(|_| core::fmt::Error)
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,12 +41,11 @@ macro_rules! adapt_serial {
 
         impl<T, E> core::fmt::Write for $wrapper<T>
         where
-            T: embedded_io::Write<u8, Error = E>,
+            T: embedded_hal::serial::Write<u8, Error = E>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 for &b in s.as_bytes() {
-                    embedded_io::Write::write(&mut self.0, &[b])
-                        .map_err(|_| core::fmt::Error)?;
+                    nb::block!(self.0.write(b)).map_err(|_| core::fmt::Error)?;
                 }
                 Ok(())
             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,11 +40,11 @@ macro_rules! adapt_serial {
 
         impl<T, E> core::fmt::Write for $wrapper<T>
         where
-            T: embedded_io::blocking::Write<u8, Error = E>,
+            T: embedded_hal::blocking::Write<u8, Error = E>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 for &b in s.as_bytes() {
-                    embedded_io::blocking::Write::write(&mut self.0, &[b])
+                    embedded_hal::blocking::Write::write(&mut self.0, &[b])
                         .map_err(|_| core::fmt::Error)?;
                 }
                 Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,10 +15,11 @@
 ///
 /// # Example:
 /// ```ignore
+/// use embedded_io::Write;
 /// adapt_serial!(UsartAdapter, nb_write = write, error = nb::Error<Infallible>, flush = flush);
 /// let mut uart = UsartAdapter(serial);
 /// writeln!(uart, "Hello!").unwrap();
-/// uart.write(&[0x01, 0x02]).unwrap();
+/// uart.write_all(&[0x01, 0x02]).unwrap();
 /// ```
 #[macro_export]
 macro_rules! adapt_serial {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,12 +56,12 @@
 /// ```
 #[macro_export]
 macro_rules! adapt_serial {
-    // common inplementation
-    (@impls $wrapper:ty, $write_fn:ident) => {
+    // common implementation
+    (@impls $wrapper:ident, $inner:ident, $write_fn:ident) => {
         impl core::fmt::Write for $wrapper {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 for &b in s.as_bytes() {
-                    self.$write_fn(b).map_err(|_| core::fmt::Error)?;
+                    self.$inner.$write_fn(b).map_err(|_| core::fmt::Error)?;
                 }
                 Ok(())
             }
@@ -70,27 +70,23 @@ macro_rules! adapt_serial {
         impl embedded_hal::blocking::serial::Write<u8> for $wrapper {
             type Error = ();
             fn bwrite_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
-                for &b in buf { self.$write_fn(b).map_err(|_| ())?; }
+                for &b in buf { self.$inner.$write_fn(b).map_err(|_| ())?; }
                 Ok(())
             }
             fn bflush(&mut self) -> Result<(), Self::Error> { Ok(()) }
         }
     };
 
-    // AVR USART
-    (avr_usart: $wrapper:ident, $instance:expr, $write_fn:ident) => {
-        pub struct $wrapper<T>(pub T);
-        impl From<typeof($instance)> for $wrapper<typeof($instance)> {
-            fn from(s: typeof($instance)) -> Self { Self(s) }
-        }
-
-        adapt_serial!(@impls $wrapper<typeof($instance)>, $write_fn);
+    // AVR USART (Type inference wrapping)
+    (avr_usart: $wrapper:ident, $instance:ident, $write_fn:ident) => {
+        pub struct $wrapper(pub _); // Encapsulating USART with type inference
+        adapt_serial!(@impls $wrapper, 0, $write_fn);
     };
 
-    // Generic serial type
+    // Generic serial
     (generic: $wrapper:ident, $target:ty, $write_fn:ident) => {
         pub struct $wrapper(pub $target);
-        adapt_serial!(@impls $wrapper, $write_fn);
+        adapt_serial!(@impls $wrapper, 0, $write_fn);
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,7 @@
 /// # Example:
 /// ```ignore
 /// use embedded_io::Write;
-/// adapt_serial!(UsartAdapter, nb_write = write, error = nb::Error<Infallible>, flush = flush);
+/// adapt_serial!(UsartAdapter, nb_write = write, error = Infallible, flush = flush);
 /// let mut uart = UsartAdapter(serial);
 /// writeln!(uart, "Hello!").unwrap();
 /// uart.write_all(&[0x01, 0x02]).unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,16 +87,7 @@ macro_rules! adapt_serial {
 
         impl<T: embedded_io::Write> core::fmt::Write for $name<T> {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
-                // write_all compatible
-                let mut left = s.as_bytes();
-                while !left.is_empty() {
-                    match self.0.write(left) {
-                        Ok(0) => return Err(core::fmt::Error),
-                        Ok(n) => left = &left[n..],
-                        Err(_) => return Err(core::fmt::Error),
-                    }
-                }
-                Ok(())
+                self.0.write_all(s.as_bytes()).map_err(|_| core::fmt::Error)
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,11 +41,11 @@ macro_rules! adapt_serial {
 
         impl<T, E> core::fmt::Write for $wrapper<T>
         where
-            T: embedded_io::blocking::Write<u8, Error = E>,
+            T: embedded_io::Write<u8, Error = E>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 for &b in s.as_bytes() {
-                    embedded_io::blocking::Write::write(&mut self.0, &[b])
+                    embedded_io::Write::write(&mut self.0, &[b])
                         .map_err(|_| core::fmt::Error)?;
                 }
                 Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,13 +89,13 @@ macro_rules! adapt_serial {
     // Internal helper for AVR-HAL USARTs
     (@avr_usart_impl $name:ident : $wrapper:ident, $write_fn:ident) => {
         pub struct $wrapper<RX, TX, CLOCK>(
-            pub arduino_hal::hal::usart::Usart<arduino_hal::pac::Peripherals, RX, TX, CLOCK>
+            pub arduino_hal::hal::usart::Usart<RX, TX, CLOCK>
         );
 
         adapt_serial!(@impls $name: $wrapper, $write_fn,
             <RX, TX, CLOCK>,
-            where arduino_hal::pac::Peripherals:
-                arduino_hal::usart::UsartOps<arduino_hal::pac::Peripherals, RX, TX>
+            where arduino_hal::hal::usart::Usart<RX, TX, CLOCK>:
+                arduino_hal::usart::UsartOps<RX, TX>
         );
     };
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,13 +12,9 @@
 /// Wraps a serial peripheral that implements `embedded_hal::serial::Write<Word=u8>`
 /// and provides `core::fmt::Write` for easy `write!`/`writeln!`.
 ///
-/// # Arguments
-/// - `$wrapper`: newtype wrapper name
-/// - `$serial`: variable name of the HAL serial
-///
 /// # Example
 /// ```ignore
-/// adapt_serial!(UsartAdapter, serial);
+/// adapt_serial!(UsartAdapter);
 /// let mut uart = UsartAdapter(serial);
 /// writeln!(uart, "Hello!").ok();
 /// ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -101,8 +101,8 @@ macro_rules! adapt_serial {
     };
 
     // AVR-HAL USART (ATmega)
-    (avr_usart: $wrapper:ident, $write_fn:ident) => {
-        adapt_serial!(@avr_usart_impl $wrapper, $write_fn);
+    (avr_usart: $name:ident : $wrapper:ident, $write_fn:ident) => {
+        adapt_serial!(@avr_usart_impl $name: $wrapper, $write_fn);
     };
 
     // Generic serial type


### PR DESCRIPTION
# 🚀 Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #46 #48 #49 #50 
- Response details: Implement glue e-hal 1.0 & e-io latest & avr support  

## Change details

- [x] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
# embedded: Serial output or LED confirmation, etc.
```

## Target board with confirmed operation
 - [x] ATmega328p
 - [x] ESP32
 - [ ] STM32
 - [ ] Linux mock
 - [ ] Other: ___

---