### PR TITLE
hotfix-46-48-52

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,10 +9,6 @@
 
 /// Macro to adapt a serial peripheral into a fmt::Write + embedded_io::Write bridge.
 ///
-/// # Variants
-/// - nb_write: wraps `nb`-style `write(byte)`
-/// - io_passthrough: wraps `embedded_io::Write` directly
-///
 /// # Example
 /// ```ignore
 /// use core::convert::Infallible;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,6 +9,9 @@
 
 /// Macro to adapt a serial peripheral into a fmt::Write + embedded_io::Write bridge.
 ///
+/// io_passthrough variant basically does nothing but pass types, so it has little value in actual use and was removed 
+/// in 657cf32afe702eb3279f0b546167745e9f2df7e9 to avoid ‘unnecessary complexity.’
+/// 
 /// # Example
 /// ```ignore
 /// use core::convert::Infallible;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,8 +9,7 @@
 
 /// Macro to adapt a serial peripheral into a fmt::Write + embedded_io::Write bridge.
 ///
-/// io_passthrough variant basically does nothing but pass types, so it has little value in actual use and was removed 
-/// in 657cf32afe702eb3279f0b546167745e9f2df7e9 to avoid ‘unnecessary complexity.’
+/// io_passthrough variant was removed as it provided little value and added unnecessary complexity.
 /// 
 /// # Example
 /// ```ignore

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,6 +16,7 @@
 /// use core::convert::Infallible;
 /// use arduino_hal::prelude::*;
 /// use dvcdbg::adapt_serial;
+/// use core::fmt::Write;
 ///
 /// let dp = arduino_hal::Peripherals::take().unwrap();
 /// let pins = arduino_hal::pins!(dp);
@@ -24,10 +25,10 @@
 /// adapt_serial!(UsartAdapter, nb_write = write, error = Infallible, flush = flush);
 ///
 /// let mut dbg_uart = UsartAdapter(serial);
-/// use core::fmt::Write;
 /// writeln!(dbg_uart, "Hello AVR!").ok();
-/// dbg_uart.write_all(&[0x01, 0x02]).unwrap();
-/// dbg_uart.flush().unwrap();
+/// // Use fully qualified syntax to avoid name conflicts with core::fmt::Write
+/// embedded_io::Write::write_all(&mut dbg_uart, &[0x01, 0x02]).unwrap();
+/// embedded_io::Write::flush(&mut dbg_uart).unwrap();
 /// ```
 #[macro_export]
 macro_rules! adapt_serial {


### PR DESCRIPTION
# 🚀 Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #46 #47 #48 #49 #50 #51 #52
- Response details: Import Infallible correctly & Implement embedded_io::ErrorType in wrapper &
nb_write variant calls write and flush correctly & flush is optional


## Change details

- [ ] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

## Target board with confirmed operation
 - [x] ATmega328p
 - [x] ESP32
 - [ ] STM32
 - [ ] Linux mock
 - [ ] Other: ___

---