### PR TITLE
Support #56

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,17 @@ pub mod macros;
 /// use dvcdbg::prelude::*;
 /// ```
 pub mod prelude;
+
+/// error type and implementation
+///
+#[derive(Debug)]
+pub enum AdaptError<E> {
+    /// The underlying I/O error.
+    Other(E),
+}
+
+impl<E: core::fmt::Debug> embedded_io::Error for AdaptError<E> {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,21 @@ pub mod macros;
 /// ```
 pub mod prelude;
 
-/// error type and implementation
+/// Error type returned by [`adapt_serial!`] adapters.
 ///
+/// This type is part of the public API, but its exact variants may change
+/// in a minor release. Prefer matching with `_` to stay forward-compatible.
+///  
+/// This is public because wiring issues are common in prototyping,
+/// and users may want to handle them (e.g., retries, logging).
 #[derive(Debug)]
 pub enum AdaptError<E> {
-    /// The underlying I/O error.
+    /// Formatting failure (e.g., `core::fmt::Write`).
+    Fmt,
+    /// HAL-specific error.
     Other(E),
 }
+
 
 impl<E: core::fmt::Debug> embedded_io::Error for AdaptError<E> {
     fn kind(&self) -> embedded_io::ErrorKind {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod prelude;
 #[derive(Debug)]
 pub enum AdaptError<E> {
     /// Formatting failure (e.g., `core::fmt::Write`).
+    /// This variant is not currently used, 
+    /// but is reserved for compatibility absorption in the event of future disruptive changes.
     Fmt,
     /// HAL-specific error.
     Other(E),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,19 +10,18 @@
 /// Macro to adapt a serial peripheral into a fmt::Write + embedded_io::Write bridge.
 ///
 /// # Arguments
-/// - '$name' -> Name of the generated structure
-/// - 'nb_write' -> Serial write function name required by HAL
-/// - 'flush(optional)' -> Function for non-blocking transmission of one byte at a time using the nb crate function
+/// - `$name` → Name of the generated adapter struct
+/// - `nb_write` → Serial write method name required by HAL
+/// - `flush` (optional) → Method for flushing non-blocking serial
 ///
 /// # Example
 ///
-/// ## Using Arduino HAL Serial
+/// ## Arduino HAL Serial
 /// ```ignore
 /// use arduino_hal::prelude::*;
 /// use dvcdbg::adapt_serial;
 /// use core::fmt::Write;
 ///
-/// // Wrap the built-in serial
 /// adapt_serial!(UsartAdapter, nb_write = write, flush = flush);
 ///
 /// let dp = arduino_hal::Peripherals::take().unwrap();
@@ -31,78 +30,69 @@
 /// let mut dbg_uart = UsartAdapter(serial);
 ///
 /// writeln!(dbg_uart, "Hello from embedded-io bridge!").unwrap();
-/// embedded_io::Write::write_all(&mut dbg_uart, &[0x01, 0x02, 0x03]).unwrap();
+/// dbg_uart.write_all(&[0x01, 0x02, 0x03]).unwrap();
 /// ```
 ///
-/// ## Using a custom serial-like type
+/// ## Custom serial-like type
 /// ```ignore
 /// use dvcdbg::adapt_serial;
-/// use core::convert::Infallible;
 /// use core::fmt::Write;
+/// use core::convert::Infallible;
 /// use nb;
 ///
-/// // Define a simple serial-like type
 /// struct MySerial;
-///
 /// impl nb::serial::Write<u8> for MySerial {
 ///     type Error = Infallible;
-///
-///     fn write(&mut self, _byte: u8) -> nb::Result<(), Self::Error> {
-///         Ok(())
-///     }
-///
-///     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-///         Ok(())
-///     }
+///     fn write(&mut self, _byte: u8) -> nb::Result<(), Self::Error> { Ok(()) }
+///     fn flush(&mut self) -> nb::Result<(), Self::Error> { Ok(()) }
 /// }
 ///
-/// // Adapt it with the macro
 /// adapt_serial!(MyAdapter, nb_write = write, flush = flush);
-///
 /// let mut uart = MyAdapter(MySerial);
 /// writeln!(uart, "Hello via custom serial").unwrap();
-/// embedded_io::Write::write_all(&mut uart, &[0xAA, 0xBB]).unwrap();
+/// uart.write_all(&[0xAA, 0xBB]).unwrap();
 /// ```
 #[macro_export]
 macro_rules! adapt_serial {
-    // nb_write variant
     ($name:ident, nb_write = $write_fn:ident $(, flush = $flush_fn:ident)?) => {
+        use core::convert::Infallible;
+        use embedded_io::Write as IoWrite;
+        use nb::block;
+        use nb::serial::Write as NbWrite;
+
         /// Serial adapter wrapper
         pub struct $name<T>(pub T);
 
         /// Implement embedded-io Write for the wrapper
-        impl<T> embedded_io::Write for $name<T>
+        impl<T> IoWrite for $name<T>
         where
-            T: nb::serial::Write<u8, Error = core::convert::Infallible>,
+            T: NbWrite<u8, Error = Infallible>,
         {
-            type Error = core::convert::Infallible;
+            type Error = Infallible;
 
             fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
                 for &b in buf {
-                    nb::block!(self.0.$write_fn(b))?;
+                    block!(self.0.$write_fn(b))?;
                 }
                 Ok(buf.len())
             }
 
             fn flush(&mut self) -> Result<(), Self::Error> {
-                $(
-                    nb::block!(self.0.$flush_fn())?;
-                )?
+                $(block!(self.0.$flush_fn())?;)?
                 Ok(())
             }
         }
 
-        /// Implement core::fmt::Write for use with writeln! / write!
+        /// Implement core::fmt::Write for writeln! / write!
         impl<T> core::fmt::Write for $name<T>
         where
-            T: nb::serial::Write<u8, Error = core::convert::Infallible>,
+            $name<T>: IoWrite<Error = Infallible>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
-                <Self as embedded_io::Write>::write_all(self, s.as_bytes())
-                    .map_err(|_| core::fmt::Error)
+                IoWrite::write_all(self, s.as_bytes()).map_err(|_| core::fmt::Error)
             }
         }
-    }
+    };
 }
 
 /// Writes a byte slice in hexadecimal format to a `fmt::Write` target.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,7 +61,7 @@ macro_rules! adapt_serial {
         pub struct $name<T>(pub T);
 
         /// Implement embedded-io Write for the wrapper
-                impl<T> embedded_io::Write for $name<T>
+        impl<T> embedded_io::Write for $name<T>
         where
             T: nb::serial::Write<u8>,
             <T as nb::serial::Write<u8>>::Error: core::fmt::Debug,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -57,12 +57,11 @@
 #[macro_export]
 macro_rules! adapt_serial {
     ($name:ident, nb_write = $write_fn:ident $(, flush = $flush_fn:ident)?) => {
-            ($name:ident, nb_write = $write_fn:ident $(, flush = $flush_fn:ident)?) => {
         /// Serial adapter wrapper
         pub struct $name<T>(pub T);
 
         /// Implement embedded-io Write for the wrapper
-        impl<T>: embedded_io::Write for $name<T>
+        impl<T> embedded_io::Write for $name<T>
         where
             T: nb::serial::Write<u8>,
         {
@@ -80,17 +79,16 @@ macro_rules! adapt_serial {
         }
 
         /// Implement core::fmt::Write for writeln! / write!
-        impl<T>: core::fmt::Write for $name<T>
+        impl<T> core::fmt::Write for $name<T>
         where
             T: nb::serial::Write<u8>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
-                <Self as embedded_io::Write> write_all(self, s.as_bytes())
+                <Self as embedded_io::Write>::write_all(self, s.as_bytes())
                     .map_err(|_| core::fmt::Error)
             }
         }
     };
-}
 }
 
 /// Writes a byte slice in hexadecimal format to a `fmt::Write` target.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -62,31 +62,31 @@ macro_rules! adapt_serial {
         pub struct $name<T>(pub T);
 
         /// Implement embedded-io Write for the wrapper
-        impl<T> ::embedded_io::Write for $name<T>
+        impl<T>: embedded_io::Write for $name<T>
         where
-            T: ::nb::serial::Write<u8>,
+            T: nb::serial::Write<u8>,
         {
-            type Error = <T as ::nb::serial::Write<u8>>::Error;
+            type Error = <T as nb::serial::Write<u8>>::Error;
             fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
                 for &b in buf {
-                    ::nb::block!(self.0.$write_fn(b))?;
+                    nb::block!(self.0.$write_fn(b))?;
                 }
                 Ok(buf.len())
             }
             fn flush(&mut self) -> Result<(), Self::Error> {
-                $(::nb::block!(self.0.$flush_fn())?;)?
+                $(nb::block!(self.0.$flush_fn())?;)?
                 Ok(())
             }
         }
 
         /// Implement core::fmt::Write for writeln! / write!
-        impl<T> ::core::fmt::Write for $name<T>
+        impl<T>: core::fmt::Write for $name<T>
         where
-            T: ::nb::serial::Write<u8>,
+            T: nb::serial::Write<u8>,
         {
-            fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-                <Self as ::embedded_io::Write>::write_all(self, s.as_bytes())
-                    .map_err(|_| ::core::fmt::Error)
+            fn write_str(&mut self, s: &str) -> core::fmt::Result {
+                <Self as embedded_io::Write> write_all(self, s.as_bytes())
+                    .map_err(|_| core::fmt::Error)
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,7 +55,6 @@
 #[macro_export]
 macro_rules! adapt_serial {
     ($name:ident, nb_write = $write_fn:ident $(, flush = $flush_fn:ident)?) => {
-        use core::convert::Infallible;
         use embedded_io::Write as IoWrite;
         use nb::block;
         use nb::serial::Write as NbWrite;
@@ -66,9 +65,9 @@ macro_rules! adapt_serial {
         /// Implement embedded-io Write for the wrapper
         impl<T> IoWrite for $name<T>
         where
-            T: NbWrite<u8, Error = Infallible>,
+            T: NbWrite<u8, Error = core::convert::Infallible>,
         {
-            type Error = Infallible;
+            type Error = core::convert::Infallible;
 
             fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
                 for &b in buf {
@@ -86,7 +85,7 @@ macro_rules! adapt_serial {
         /// Implement core::fmt::Write for writeln! / write!
         impl<T> core::fmt::Write for $name<T>
         where
-            $name<T>: IoWrite<Error = Infallible>,
+            $name<T>: IoWrite<Error = core::convert::Infallible>,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 IoWrite::write_all(self, s.as_bytes()).map_err(|_| core::fmt::Error)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,19 +61,20 @@ macro_rules! adapt_serial {
         pub struct $name<T>(pub T);
 
         /// Implement embedded-io Write for the wrapper
-        impl<T> embedded_io::Write for $name<T>
+                impl<T> embedded_io::Write for $name<T>
         where
             T: nb::serial::Write<u8>,
+            <T as nb::serial::Write<u8>>::Error: core::fmt::Debug,
         {
-            type Error = <T as nb::serial::Write<u8>>::Error;
+            type Error = $crate::AdaptError<<T as nb::serial::Write<u8>>::Error>;
             fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
                 for &b in buf {
-                    nb::block!(self.0.$write_fn(b))?;
+                    nb::block!(self.0.$write_fn(b)).map_err($crate::AdaptError::Other)?;
                 }
                 Ok(buf.len())
             }
             fn flush(&mut self) -> Result<(), Self::Error> {
-                $(nb::block!(self.0.$flush_fn())?;)?
+                $(nb::block!(self.0.$flush_fn()).map_err($crate::AdaptError::Other)?;)?
                 Ok(())
             }
         }
@@ -82,6 +83,7 @@ macro_rules! adapt_serial {
         impl<T> core::fmt::Write for $name<T>
         where
             T: nb::serial::Write<u8>,
+            <T as nb::serial::Write<u8>>::Error: core::fmt::Debug,
         {
             fn write_str(&mut self, s: &str) -> core::fmt::Result {
                 <Self as embedded_io::Write>::write_all(self, s.as_bytes())


### PR DESCRIPTION
# 🚀 Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #56 
- Response details:
  - Constrain the nb::serial::Write trait to ensure that T has a write method.
  - flush is optional; use it only when asynchronous transmission is required for the Arduino HAL.
  - core::fmt::Write does not have flush and provides write_str for writeln!
  - Implement embedded_io::Write correctly so that write_all and flush work
  - Treat Infallible error types as the default, but allow generic type specification

## Change details

- [x] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

## Target board with confirmed operation
 - [x] ATmega328p
 - [x] ESP32
 - [ ] STM32
 - [ ] Linux mock
 - [ ] Other: ___

---