### PR TITLE
Do not use nb::Write at the boundary; call it via DerefMut.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -74,8 +74,7 @@ macro_rules! adapt_serial {
             }
 
             fn flush(&mut self) -> Result<(), embedded_io::Error> {
-                $(nb::block!(self.0.$flush_fn())
-                    .map_err(|_| embedded_io::ErrorKind::Other)?;)?
+                $(nb::block!(self.0.$flush_fn()).map_err(|_| embedded_io::ErrorKind::Other)?;)?
                 Ok(())
             }
         }


### PR DESCRIPTION
# 🚀 Pull Request

## Overview

<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #56 
- Response details: 
  - nb::Write is not used at boundaries, but is called via DerefMut.
  - embedded_io::Write has no associated type and always returns embedded_io::Error.
  - flush is optional.

## Change details

- [ ] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

## Target board with confirmed operation
 - [x] ATmega328p
 - [x] ESP32
 - [ ] STM32
 - [ ] Linux mock
 - [ ] Other: ___

---