### PR TITLE
Refactoring src/compat/serial_compat.rs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,7 +30,7 @@
 /// struct MySerial;
 /// impl SerialCompat for MySerial {
 ///     type Error = ();
-    fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> { Ok(()) }
+///     fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> { Ok(()) }
 ///     fn flush(&mut self) -> Result<(), Self::Error> { Ok(()) }
 /// }
 ///


### PR DESCRIPTION
# 🚀 Pull Request

## Overview
### SerialCompat trait
Changed the signature of the write method to fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> and unified it to be slice-oriented. This makes it consistent with the approaches of ehal_1_0 and embedded-io.

### ehal_1_0 implementation
There are few changes to align with the new definition of SerialCompat. By leveraging embedded_io::Write::write_all, efficient buffer writing is achieved.

### ehal_0_2 implementation
Since embedded-hal v0.2 is byte-oriented, we have modified it to process the input byte slice in a loop and write each byte individually. This adapts the old byte-based API to the new slice-based trait.
<!-- Describe the issue that this PR solves and its purpose. -->
- Related Issue: #74

## Change details

- [x] New feature
- [x] Refactoring
- [x] Bug fix
- [ ] CI / Build settings correction
- [ ] Documentation update

## Build / Test Results

```sh
$ cargo check     # ✅
$ cargo test      # ✅
```

## Target board with confirmed operation
 - [x] ATmega328p
 - [x] ESP32
 - [x] STM32
 - [ ] Linux mock
 - [ ] Other: ___

---